### PR TITLE
 Update Prettier Config: Adjust printWidth for Apex, LWC, and XML

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,12 +3,13 @@
   "endOfLine": "lf",
   "useTabs": false,
   "tabWidth": 2,
+  "printWidth": 120,
   "plugins": ["prettier-plugin-apex", "@prettier/plugin-xml"],
   "overrides": [
     {
       "files": "*.{cls,apexc,trigger}",
       "options": {
-        "printWidth": 100,
+        "printWidth": 120,
         "useTabs": false,
         "tabWidth": 4,
         "apexInsertFinalNewline": true
@@ -17,7 +18,7 @@
     {
       "files": "*.apex",
       "options": {
-        "printWidth": 100,
+        "printWidth": 120,
         "useTabs": false,
         "tabWidth": 4,
         "apexInsertFinalNewline": true,
@@ -27,6 +28,7 @@
     {
       "files": "**/lwc/**/*.html",
       "options": {
+        "printWidth": 120,
         "parser": "lwc",
         "bracketSameLine": true
       }
@@ -34,6 +36,7 @@
     {
       "files": "*.{cmp,page,component}",
       "options": {
+        "printWidth": 120,
         "parser": "html",
         "bracketSameLine": true
       }
@@ -41,6 +44,7 @@
     {
       "files": "*-meta.xml",
       "options": {
+        "printWidth": 100,
         "tabWidth": 4,
         "useTabs": false,
         "bracketSameLine": true,


### PR DESCRIPTION
# Prettier `printWidth` Guidelines

The ideal `printWidth` in Prettier depends on readability, project conventions, and personal/team preferences.  

## General Recommendations:
- **80 characters (default)** – Ideal for better readability, especially on smaller screens, split editors, and terminal-based editing.  
- **100-120 characters** – Often preferred for modern widescreen monitors, reducing excessive line breaks while maintaining readability.  
- **120+ characters** – Useful in cases like JSON or configuration files where breaking lines might reduce clarity.  

## Salesforce-Specific Context:
Since we work with **Apex, LWC, and XML**, below are considered in this PR:  
- **100 or 120 characters** for Apex (`prettier-plugin-apex`) to balance readability with reducing excessive wrapping.  
- **100 or 120 characters** for LWC JavaScript and HTML, as Salesforce code tends to have deeply nested structures.  
- **80 or 100 characters** for XML (`@prettier/plugin-xml`) to avoid excessive horizontal scrolling, especially in metadata files.  

## What's New:
- **Apex & LWC:** Increased `printWidth` to **120** for improved readability and reduced unnecessary line breaks.  
- **XML**: Set `printWidth` to **100** to balance clarity and avoid excessive horizontal scrolling.  
- Maintained existing formatting rules and plugin configurations.  
